### PR TITLE
docs: fix web3 capitalization

### DIFF
--- a/guides/swaps/batch-swaps.md
+++ b/guides/swaps/batch-swaps.md
@@ -355,7 +355,7 @@ path_abi_vault = '../abis/Vault.json'
 with open(path_abi_vault) as f:
   abi_vault = json.load(f)
 contract_vault = web3.eth.contract(
-	address=web3.toChecksumAddress(address_vault), 
+	address=Web3.toChecksumAddress(address_vault), 
 	abi=abi_vault
 )
 ```
@@ -476,9 +476,9 @@ for step in swap_steps:
 	swaps_step_structs.append(swaps_step_struct)
 
 fund_struct = (
-	web3.toChecksumAddress(fund_settings["sender"]),
+	Web3.toChecksumAddress(fund_settings["sender"]),
 	fund_settings["fromInternalBalance"],
-	web3.toChecksumAddress(fund_settings["recipient"]),
+	Web3.toChecksumAddress(fund_settings["recipient"]),
 	fund_settings["toInternalBalance"]
 )
 ```
@@ -519,7 +519,7 @@ The only real "gotcha" here is to make sure your **address**es are in checksum f
 
 ```python
 token_limits = [int(Decimal(token_data[token]["limit"]) * 10 ** Decimal(token_data[token]["decimals"])) for token in token_addresses]
-checksum_tokens = [web3.toChecksumAddress(token) for token in token_addresses]
+checksum_tokens = [Web3.toChecksumAddress(token) for token in token_addresses]
 ```
 
 Here, we're scaling our **token\_limits** to account for the token-specific decimals, and converting all our token addresses to checksum format instead of lowercase.

--- a/guides/swaps/single-swaps.md
+++ b/guides/swaps/single-swaps.md
@@ -316,7 +316,7 @@ path_abi_vault = '../abis/Vault.json'
 with open(path_abi_vault) as f:
   abi_vault = json.load(f)
 contract_vault = web3.eth.contract(
-	address=web3.toChecksumAddress(address_vault), 
+	address=Web3.toChecksumAddress(address_vault), 
 	abi=abi_vault
 )
 ```
@@ -409,16 +409,16 @@ user_data_encoded = eth_abi.encode_abi(['uint256'], [0])
 swap_struct = (
 	swap["poolId"],
 	swap_kind,
-	web3.toChecksumAddress(swap["assetIn"]),
-	web3.toChecksumAddress(swap["assetOut"]),
+	Web3.toChecksumAddress(swap["assetIn"]),
+	Web3.toChecksumAddress(swap["assetOut"]),
 	int(Decimal(swap["amount"]) * 10 ** Decimal((token_data[swap["assetIn"]]["decimals"]))),
 	user_data_encoded
 )
 
 fund_struct = (
-	web3.toChecksumAddress(fund_settings["sender"]),
+	Web3.toChecksumAddress(fund_settings["sender"]),
 	fund_settings["fromInternalBalance"],
-	web3.toChecksumAddress(fund_settings["recipient"]),
+	Web3.toChecksumAddress(fund_settings["recipient"]),
 	fund_settings["toInternalBalance"]
 )
 


### PR DESCRIPTION
Web3 should be capitalized here, as in [the web3 docs](https://web3py.readthedocs.io/en/stable/web3.main.html?highlight=toChecksumAddress#web3.Web3.toChecksumAddress)